### PR TITLE
bug fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>LATEST</version>
+            <version>1.12.2-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/com/gmail/encryptdev/morecrafting/listener/WorkbenchInteractListener.java
+++ b/src/main/java/com/gmail/encryptdev/morecrafting/listener/WorkbenchInteractListener.java
@@ -5,6 +5,7 @@ import com.gmail.encryptdev.morecrafting.inventory.AbstractInventory;
 import com.gmail.encryptdev.morecrafting.inventory.WorkbenchInventory;
 import com.gmail.encryptdev.morecrafting.util.MessageTranslator;
 import org.bukkit.ChatColor;
+import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -92,7 +93,13 @@ public class WorkbenchInteractListener implements Listener {
                 }
 
                 invContent = Arrays.copyOfRange(invContent, 0, index);
-                player.getInventory().addItem(invContent);
+                for (ItemStack is:invContent) {
+                    if (player.getInventory().firstEmpty() != -1) {
+                        player.getInventory().addItem(invContent);
+                    }else{
+                        player.getWorld().dropItemNaturally(player.getLocation(),is);
+                    }
+                }
 
             }
     }

--- a/src/main/java/com/gmail/encryptdev/morecrafting/util/BlockListFile.java
+++ b/src/main/java/com/gmail/encryptdev/morecrafting/util/BlockListFile.java
@@ -14,6 +14,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 /**
  * Created by EncryptDev
@@ -45,13 +46,13 @@ public class BlockListFile {
             list = new ArrayList<>();
         for (String str : list) {
             String[] data = str.split(":");
-            World world = Bukkit.getWorld(data[0]);
+            World world = Bukkit.getWorld(UUID.fromString(data[0]));
             int x = Integer.parseInt(data[1]);
             int y = Integer.parseInt(data[2]);
             int z = Integer.parseInt(data[3]);
             String owner = "";
             if (data.length == 5)
-                owner = data[5];
+                owner = data[4];
             if (world.getBlockAt(x, y, z).getType() == Material.WORKBENCH) {
                 world.getBlockAt(x, y, z).setMetadata(MoreCrafting.CRAFTING_META_DATA,
                         new FixedMetadataValue(MoreCrafting.getInstance(), "CUSTOM-CRAFTER"));
@@ -109,7 +110,7 @@ public class BlockListFile {
     }
 
     private String locationString(Location location) {
-        return location.getWorld().getName() + ":" + (int) location.getX() + ":" + (int) location.getY() + ":" + (int) location.getZ();
+        return location.getWorld().getUID().toString() + ":" + (int) location.getX() + ":" + (int) location.getY() + ":" + (int) location.getZ();
     }
 
 }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -2,7 +2,7 @@ name: MoreCrafting
 author: EncryptDev
 main: com.gmail.encryptdev.morecrafting.MoreCrafting
 version: 1.3
-
+depend: [Multiverse-Core]
 commands:
   mc:
     aliases: [morecrafting, morec, mcrafting]


### PR DESCRIPTION
We'd like your project very much. We'd be glad to help you to improve your plugin to be better. So we have fixed some bugs. Here what they are:
1. World name is unsafe anymore, So I use UUID of World instead
2. If use world plugin like "mv" to create a world. The MoreCraft will be loaded before the world. It will cause an error in (BlockListFile.java:55). My solution is to make the "mv" plugin as a dependent plugin.
I know a better solution, but I won't write it. Because you're the owner of the plugin.
3. if Player Inventory is full, the item in inventory won't return to the player. So I make them drop at where the player area.
4. Enum class "Material" in 1.13 won't support "WORKBENCH", So I make spigot-API-1.12.2 as a  dependence in pom.xml.

Thank you